### PR TITLE
[#1]issueテンプレートの作成

### DIFF
--- a/.github/ISSUE_TEMPLATE/AddFeatureReport.md
+++ b/.github/ISSUE_TEMPLATE/AddFeatureReport.md
@@ -1,0 +1,22 @@
+---
+name: 機能追加
+about: 欲しい機能がある場合のissue
+title: 'enhancement_〇〇'
+labels: 'enhancement'
+assignees: 'ShoumaNakajima'
+
+---
+
+---
+name: 機能追加
+about: 欲しい機能がある場合のissue
+---
+
+
+## 欲しい機能内容
+
+## なぜその機能が欲しい理由
+
+## 実装方法
+
+## 参考資料

--- a/.github/ISSUE_TEMPLATE/BugReport.md
+++ b/.github/ISSUE_TEMPLATE/BugReport.md
@@ -1,0 +1,20 @@
+---
+name: バグ報告
+about: バグ報告のためのissue
+title: 'bug_〇〇'
+labels: 'bug'
+assignees: 'ShoumaNakajima'
+---
+
+---
+name: バグ報告
+about: バグ報告のためのissue
+---
+
+## 不具合の内容
+
+## 不具合の再現方法
+
+## 正しい動作
+
+## 参考情報

--- a/.github/ISSUE_TEMPLATE/ModifyFeatureReport.md
+++ b/.github/ISSUE_TEMPLATE/ModifyFeatureReport.md
@@ -1,0 +1,20 @@
+---
+name: 機能の修正、変更
+about: 修正や変更して欲しい機能がある場合のissue
+title: 'enhancement_〇〇'
+labels: 'enhancement'
+assignees: 'ShoumaNakajima'
+---
+
+---
+name: 機能の修正、変更
+about: 修正や変更して欲しい機能がある場合のissue
+---
+
+## 修正や変更して欲しい機能の内容
+
+## 修正矢変更して欲しい理由
+
+## 実装方法
+
+## 参考資料


### PR DESCRIPTION
## 概要
issueテンプレートをGithubのGUIからではなく、
フォルダやファイルを作成して追加する

refs #1 

## 動作要件
新しいisssueを作成するときにテンプレートを選ぶことが出来るようになり、
選んだテンプレートが入力された状態からissueを作成することが出来るようにする。
